### PR TITLE
Add duplicate target detection to QA check script

### DIFF
--- a/scripts/properties/check_rules.properties
+++ b/scripts/properties/check_rules.properties
@@ -25,6 +25,7 @@ nameTagSpace=Tags - spaces
 nameTagOrder=Tags - order
 nameNumErr=Inconsistent numbers
 nameSpellErr=Spelling errors(s)
+nameSameTargetDiffSource=Identical target with different source
 
 checkWholeProject=Check whole project
 checkLeadSpace=Check for leading whitespace
@@ -43,7 +44,6 @@ checkTagSpace=Check spaces around tags
 checkTagOrder=Check sequence of tags
 checkNumErr=Check for inconsistent numbers
 checkSpellErr=Check for segments with spelling errors
-nameSameTargetDiffSource=Identical target with different source
 checkSameTargetDiffSource=Check for identical targets with different sources
 
 refresh=Refresh

--- a/scripts/properties/check_rules.properties
+++ b/scripts/properties/check_rules.properties
@@ -43,5 +43,7 @@ checkTagSpace=Check spaces around tags
 checkTagOrder=Check sequence of tags
 checkNumErr=Check for inconsistent numbers
 checkSpellErr=Check for segments with spelling errors
+nameSameTargetDiffSource=Identical target with different source
+checkSameTargetDiffSource=Check for identical targets with different sources
 
 refresh=Refresh


### PR DESCRIPTION
## Summary
- enhance `check_rules.groovy` with a rule to detect identical targets tied to different sources
- expose the new rule through UI checkbox
- add English resource strings for the new rule

## Testing
- `./gradlew test` *(fails: could not download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684dabf7b4bc832899926d1a40144559