### PR TITLE
Add MT and Fuzzy Matches to Auto-Completion

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2390,6 +2390,8 @@ AC_AUTOTEXT_VIEW=Autotext entries
 AC_CHARTABLE_VIEW=Character table
 AC_HISTORY_COMPLETIONS_VIEW=History Completions
 AC_HISTORY_PREDICTIONS_VIEW=History Predictions
+AC_MT_VIEW=Machine translations
+AC_FUZZY_VIEW=Fuzzy matches
 
 AC_OPTIONS_DISPLAY_SOURCE=Displa&y source terms
 AC_OPTIONS_DISPLAY_SOURCE_TOOLTIP=When checked, the items in the glossary auto-completer view will also contain the source text.

--- a/src/org/omegat/Bundle_us.properties
+++ b/src/org/omegat/Bundle_us.properties
@@ -2424,6 +2424,8 @@ AC_AUTOTEXT_VIEW=Autotext entries
 AC_CHARTABLE_VIEW=Character table
 AC_HISTORY_COMPLETIONS_VIEW=History Completions
 AC_HISTORY_PREDICTIONS_VIEW=History Predictions
+AC_MT_VIEW=Machine translations
+AC_FUZZY_VIEW=Fuzzy matches
 
 AC_OPTIONS_DISPLAY_SOURCE=Displa&y source terms
 AC_OPTIONS_DISPLAY_SOURCE_TOOLTIP=When checked, the items in the glossary auto-completer view will also contain the source text.

--- a/src/org/omegat/gui/editor/autocompleter/AutoCompleter.java
+++ b/src/org/omegat/gui/editor/autocompleter/AutoCompleter.java
@@ -51,6 +51,8 @@ import org.omegat.gui.editor.autotext.AutotextAutoCompleterView;
 import org.omegat.gui.editor.chartable.CharTableAutoCompleterView;
 import org.omegat.gui.editor.history.HistoryCompleter;
 import org.omegat.gui.editor.history.HistoryPredictor;
+import org.omegat.gui.exttrans.MachineTranslationAutoCompleterView;
+import org.omegat.gui.matches.FuzzyMatchesAutoCompleterView;
 import org.omegat.gui.glossary.GlossaryAutoCompleterView;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
@@ -109,6 +111,8 @@ public class AutoCompleter implements IAutoCompleter {
         addView(new CharTableAutoCompleterView());
         addView(new HistoryCompleter());
         addView(new HistoryPredictor());
+        addView(new org.omegat.gui.exttrans.MachineTranslationAutoCompleterView());
+        addView(new org.omegat.gui.matches.FuzzyMatchesAutoCompleterView());
 
         viewLabel = new JLabel();
         viewLabel.setBorder(new CompoundBorder(

--- a/src/org/omegat/gui/exttrans/MachineTranslateTextArea.java
+++ b/src/org/omegat/gui/exttrans/MachineTranslateTextArea.java
@@ -32,6 +32,7 @@ package org.omegat.gui.exttrans;
 
 import java.awt.Dimension;
 import java.awt.Font;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -153,6 +154,15 @@ public class MachineTranslateTextArea extends EntryInfoThreadPane<MachineTransla
         MachineTranslationInfo info = displayed.get(selectedIndex);
         highlightSelected(selectedIndex, info);
         return info;
+    }
+
+    /**
+     * Get all displayed machine translation results.
+     *
+     * @return list of translation infos
+     */
+    public List<MachineTranslationInfo> getDisplayedTranslations() {
+        return new ArrayList<>(displayed);
     }
 
     private void highlightSelected(final int selectedIndex, final MachineTranslationInfo info) {

--- a/src/org/omegat/gui/exttrans/MachineTranslationAutoCompleterView.java
+++ b/src/org/omegat/gui/exttrans/MachineTranslationAutoCompleterView.java
@@ -1,0 +1,52 @@
+package org.omegat.gui.exttrans;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.omegat.core.Core;
+import org.omegat.gui.editor.autocompleter.AutoCompleterItem;
+import org.omegat.gui.editor.autocompleter.AutoCompleterListView;
+import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
+
+/**
+ * Auto-completion view providing suggestions from machine translation results.
+ */
+public class MachineTranslationAutoCompleterView extends AutoCompleterListView {
+
+    public MachineTranslationAutoCompleterView() {
+        super(OStrings.getString("AC_MT_VIEW"));
+    }
+
+    @Override
+    public List<AutoCompleterItem> computeListData(String prevText, boolean contextualOnly) {
+        List<MachineTranslationInfo> infos = Core.getMachineTranslatePane().getDisplayedTranslations();
+        if (infos == null || infos.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String token = getLastToken(prevText);
+        List<AutoCompleterItem> result = new ArrayList<>();
+        for (MachineTranslationInfo info : infos) {
+            String tr = info.result;
+            if (contextualOnly) {
+                if (!token.isEmpty() && tr.startsWith(token) && !tr.equals(token)) {
+                    result.add(new AutoCompleterItem(tr, new String[] { info.translatorName }, token.length()));
+                }
+            } else {
+                result.add(new AutoCompleterItem(tr, new String[] { info.translatorName }, 0));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String itemToString(AutoCompleterItem item) {
+        return item.payload;
+    }
+
+    @Override
+    protected boolean isEnabled() {
+        return Preferences.isPreferenceDefault(Preferences.AC_MACHINETRANSLATION_ENABLED, true);
+    }
+}

--- a/src/org/omegat/gui/matches/FuzzyMatchesAutoCompleterView.java
+++ b/src/org/omegat/gui/matches/FuzzyMatchesAutoCompleterView.java
@@ -1,0 +1,54 @@
+package org.omegat.gui.matches;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.omegat.core.Core;
+import org.omegat.core.matching.NearString;
+import org.omegat.gui.editor.autocompleter.AutoCompleterItem;
+import org.omegat.gui.editor.autocompleter.AutoCompleterListView;
+import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
+
+/**
+ * Auto-completion view offering suggestions from fuzzy match results.
+ */
+public class FuzzyMatchesAutoCompleterView extends AutoCompleterListView {
+
+    public FuzzyMatchesAutoCompleterView() {
+        super(OStrings.getString("AC_FUZZY_VIEW"));
+    }
+
+    @Override
+    public List<AutoCompleterItem> computeListData(String prevText, boolean contextualOnly) {
+        MatchesTextArea matcher = (MatchesTextArea) Core.getMatcher();
+        List<NearString> matches = matcher.getDisplayedMatches();
+        if (matches.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String token = getLastToken(prevText);
+        List<AutoCompleterItem> result = new ArrayList<>();
+        for (NearString ns : matches) {
+            String trans = ns.translation;
+            if (contextualOnly) {
+                if (!token.isEmpty() && trans.startsWith(token) && !trans.equals(token)) {
+                    result.add(new AutoCompleterItem(trans, null, token.length()));
+                }
+            } else {
+                result.add(new AutoCompleterItem(trans, null, 0));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String itemToString(AutoCompleterItem item) {
+        return item.payload;
+    }
+
+    @Override
+    protected boolean isEnabled() {
+        return Preferences.isPreferenceDefault(Preferences.AC_FUZZY_MATCH_ENABLED, true);
+    }
+}

--- a/src/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/org/omegat/gui/matches/MatchesTextArea.java
@@ -266,6 +266,15 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
     }
 
     /**
+     * Get the list of currently displayed fuzzy matches.
+     *
+     * @return list of matches
+     */
+    public List<NearString> getDisplayedMatches() {
+        return new ArrayList<>(matches);
+    }
+
+    /**
      * Attempts to substitute numbers in a match with numbers from the source
      * segment. For substitution to be done, the number of numbers must be the
      * same between source and matches, and the numbers must be the same between

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -455,6 +455,14 @@ public final class Preferences {
     public static final String AC_HISTORY_COMPLETION_ENABLED = "allow_history_completer";
     public static final String AC_HISTORY_PREDICTION_ENABLED = "history_completer_prediction_enabled";
 
+    /** machine translation auto-completion */
+    public static final String AC_MACHINETRANSLATION_ENABLED = "ac_machine_translation_enabled";
+    public static final boolean AC_MACHINETRANSLATION_ENABLED_DEFAULT = true;
+
+    /** fuzzy match auto-completion */
+    public static final String AC_FUZZY_MATCH_ENABLED = "ac_fuzzy_match_enabled";
+    public static final boolean AC_FUZZY_MATCH_ENABLED_DEFAULT = true;
+
     /** status bar progress mode */
     public static final String SB_PROGRESS_MODE = "sb_progress_mode";
 

--- a/src_docs/manual/en/Introduction.xml
+++ b/src_docs/manual/en/Introduction.xml
@@ -847,11 +847,11 @@
       linkend="panes.editor.cursor.lock"><keycap>F2</keycap></link> and repeat
       the process to enter the target term.</para>
 
-	  <para>You have enabled the <link
-	  linkend="dialog.preferences.auto.completion">auto-completion</link> to
-	  automatically display not only history predictions, but also glossary
-	  terms, and pre-defined short strings, which can be entered with simple
-	  arrow navigation.</para>
+        <para>You have enabled the <link
+        linkend="dialog.preferences.auto.completion">auto-completion</link> to
+        automatically display not only history predictions, but also glossary
+        terms, machine translations, fuzzy matches and pre-defined short strings,
+        which can be entered with simple arrow navigation.</para>
 		
       <para>You then reach a revised section of the text where the
       <link linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/>

--- a/src_docs/manual/en/OmegaT_Preferences.xml
+++ b/src_docs/manual/en/OmegaT_Preferences.xml
@@ -586,8 +586,14 @@
 	<para>Click on <guilabel>Autotext</guilabel> to configure the Autotext
 	options, and to add or remove entries.</para>
 
-	<para>Click on <guilabel>Character Table</guilabel> to set the Character
-	table auto-completer options.</para>
+        <para>Click on <guilabel>Character Table</guilabel> to set the Character
+        table auto-completer options.</para>
+
+        <para>Click on <guilabel>Machine Translations</guilabel> to insert
+        suggestions from enabled machine translation services.</para>
+
+        <para>Click on <guilabel>Fuzzy Matches</guilabel> to enable suggestions
+        from translation memory matches.</para>
 
 	<para>Click on <guilabel>Enable history completion</guilabel> or
 	<guilabel>Enable history prediction</guilabel> to set history based


### PR DESCRIPTION
## Summary
- extend auto-completion with Machine Translation and Fuzzy Matches sources
- add view classes for MT and fuzzy matches
- expose lists of displayed MT results and fuzzy matches
- document the new sources

## Testing
- `./gradlew test` *(fails: Could not download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684db34b2bdc832890171101b95d7426