### PR TITLE
Split MT and fuzzy suggestions into words

### DIFF
--- a/src/org/omegat/gui/exttrans/MachineTranslationAutoCompleterView.java
+++ b/src/org/omegat/gui/exttrans/MachineTranslationAutoCompleterView.java
@@ -3,12 +3,15 @@ package org.omegat.gui.exttrans;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 
 import org.omegat.core.Core;
 import org.omegat.gui.editor.autocompleter.AutoCompleterItem;
 import org.omegat.gui.editor.autocompleter.AutoCompleterListView;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
+import org.omegat.tokenizer.ITokenizer;
 
 /**
  * Auto-completion view providing suggestions from machine translation results.
@@ -27,14 +30,23 @@ public class MachineTranslationAutoCompleterView extends AutoCompleterListView {
         }
         String token = getLastToken(prevText);
         List<AutoCompleterItem> result = new ArrayList<>();
+        Set<String> added = new HashSet<>();
         for (MachineTranslationInfo info : infos) {
             String tr = info.result;
-            if (contextualOnly) {
-                if (!token.isEmpty() && tr.startsWith(token) && !tr.equals(token)) {
-                    result.add(new AutoCompleterItem(tr, new String[] { info.translatorName }, token.length()));
+            String[] words = getTokenizer().tokenizeWordsToStrings(tr, ITokenizer.StemmingMode.NONE);
+            for (String word : words) {
+                if (added.contains(word)) {
+                    continue;
                 }
-            } else {
-                result.add(new AutoCompleterItem(tr, new String[] { info.translatorName }, 0));
+                if (contextualOnly) {
+                    if (!token.isEmpty() && word.startsWith(token) && !word.equals(token)) {
+                        result.add(new AutoCompleterItem(word, new String[] { info.translatorName }, token.length()));
+                        added.add(word);
+                    }
+                } else {
+                    result.add(new AutoCompleterItem(word, new String[] { info.translatorName }, 0));
+                    added.add(word);
+                }
             }
         }
         return result;

--- a/src/org/omegat/gui/matches/FuzzyMatchesAutoCompleterView.java
+++ b/src/org/omegat/gui/matches/FuzzyMatchesAutoCompleterView.java
@@ -3,6 +3,8 @@ package org.omegat.gui.matches;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 
 import org.omegat.core.Core;
 import org.omegat.core.matching.NearString;
@@ -10,6 +12,7 @@ import org.omegat.gui.editor.autocompleter.AutoCompleterItem;
 import org.omegat.gui.editor.autocompleter.AutoCompleterListView;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
+import org.omegat.tokenizer.ITokenizer;
 
 /**
  * Auto-completion view offering suggestions from fuzzy match results.
@@ -29,14 +32,23 @@ public class FuzzyMatchesAutoCompleterView extends AutoCompleterListView {
         }
         String token = getLastToken(prevText);
         List<AutoCompleterItem> result = new ArrayList<>();
+        Set<String> added = new HashSet<>();
         for (NearString ns : matches) {
             String trans = ns.translation;
-            if (contextualOnly) {
-                if (!token.isEmpty() && trans.startsWith(token) && !trans.equals(token)) {
-                    result.add(new AutoCompleterItem(trans, null, token.length()));
+            String[] words = getTokenizer().tokenizeWordsToStrings(trans, ITokenizer.StemmingMode.NONE);
+            for (String word : words) {
+                if (added.contains(word)) {
+                    continue;
                 }
-            } else {
-                result.add(new AutoCompleterItem(trans, null, 0));
+                if (contextualOnly) {
+                    if (!token.isEmpty() && word.startsWith(token) && !word.equals(token)) {
+                        result.add(new AutoCompleterItem(word, null, token.length()));
+                        added.add(word);
+                    }
+                } else {
+                    result.add(new AutoCompleterItem(word, null, 0));
+                    added.add(word);
+                }
             }
         }
         return result;


### PR DESCRIPTION
## Summary
- tokenize MT results per word for autocompletion
- tokenize fuzzy matches per word for autocompletion

## Testing
- `./gradlew test -Dorg.gradle.java.installations.auto-download=false -Dorg.gradle.java.installations.paths=$JAVA_HOME --no-daemon` *(fails: Could not resolve docbook resources)*

------
https://chatgpt.com/codex/tasks/task_e_684f1b0b80cc8328a434655394380b20