### PR TITLE
Enable context filtering for MT & fuzzy autocompletion

### DIFF
--- a/src/org/omegat/gui/exttrans/MachineTranslationAutoCompleterView.java
+++ b/src/org/omegat/gui/exttrans/MachineTranslationAutoCompleterView.java
@@ -29,27 +29,29 @@ public class MachineTranslationAutoCompleterView extends AutoCompleterListView {
             return Collections.emptyList();
         }
         String token = getLastToken(prevText);
-        List<AutoCompleterItem> result = new ArrayList<>();
-        Set<String> added = new HashSet<>();
+        List<AutoCompleterItem> contextual = new ArrayList<>();
+        List<AutoCompleterItem> all = new ArrayList<>();
+        Set<String> seenContext = new HashSet<>();
+        Set<String> seenAll = new HashSet<>();
         for (MachineTranslationInfo info : infos) {
             String tr = info.result;
             String[] words = getTokenizer().tokenizeWordsToStrings(tr, ITokenizer.StemmingMode.NONE);
             for (String word : words) {
-                if (added.contains(word)) {
-                    continue;
+                if (seenAll.add(word)) {
+                    all.add(new AutoCompleterItem(word, new String[] { info.translatorName }, 0));
                 }
-                if (contextualOnly) {
-                    if (!token.isEmpty() && word.startsWith(token) && !word.equals(token)) {
-                        result.add(new AutoCompleterItem(word, new String[] { info.translatorName }, token.length()));
-                        added.add(word);
+                if (!token.isEmpty() && word.startsWith(token) && !word.equals(token)) {
+                    if (seenContext.add(word)) {
+                        contextual.add(new AutoCompleterItem(word, new String[] { info.translatorName }, token.length()));
                     }
-                } else {
-                    result.add(new AutoCompleterItem(word, new String[] { info.translatorName }, 0));
-                    added.add(word);
                 }
             }
         }
-        return result;
+
+        if (!contextual.isEmpty() || contextualOnly) {
+            return contextual;
+        }
+        return all;
     }
 
     @Override

--- a/src/org/omegat/gui/matches/FuzzyMatchesAutoCompleterView.java
+++ b/src/org/omegat/gui/matches/FuzzyMatchesAutoCompleterView.java
@@ -31,27 +31,29 @@ public class FuzzyMatchesAutoCompleterView extends AutoCompleterListView {
             return Collections.emptyList();
         }
         String token = getLastToken(prevText);
-        List<AutoCompleterItem> result = new ArrayList<>();
-        Set<String> added = new HashSet<>();
+        List<AutoCompleterItem> contextual = new ArrayList<>();
+        List<AutoCompleterItem> all = new ArrayList<>();
+        Set<String> seenContext = new HashSet<>();
+        Set<String> seenAll = new HashSet<>();
         for (NearString ns : matches) {
             String trans = ns.translation;
             String[] words = getTokenizer().tokenizeWordsToStrings(trans, ITokenizer.StemmingMode.NONE);
             for (String word : words) {
-                if (added.contains(word)) {
-                    continue;
+                if (seenAll.add(word)) {
+                    all.add(new AutoCompleterItem(word, null, 0));
                 }
-                if (contextualOnly) {
-                    if (!token.isEmpty() && word.startsWith(token) && !word.equals(token)) {
-                        result.add(new AutoCompleterItem(word, null, token.length()));
-                        added.add(word);
+                if (!token.isEmpty() && word.startsWith(token) && !word.equals(token)) {
+                    if (seenContext.add(word)) {
+                        contextual.add(new AutoCompleterItem(word, null, token.length()));
                     }
-                } else {
-                    result.add(new AutoCompleterItem(word, null, 0));
-                    added.add(word);
                 }
             }
         }
-        return result;
+
+        if (!contextual.isEmpty() || contextualOnly) {
+            return contextual;
+        }
+        return all;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- filter machine translation autocompletion suggestions using typed text
- filter fuzzy match autocompletion suggestions using typed text

## Testing
- `./gradlew test --no-daemon` *(fails: Could not download toolchain - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684fd1c1b8208328abec9814d2286899