### PR TITLE
Fix NPE when opening SDL project archives

### DIFF
--- a/src/org/omegat/filters4/AbstractZipFilter.java
+++ b/src/org/omegat/filters4/AbstractZipFilter.java
@@ -197,9 +197,12 @@ public abstract class AbstractZipFilter extends AbstractFilter {
     private void processTranslatableEntry(ZipFile zipFile, ZipOutputStream zipOutputStream, BufferedWriter writer,
                                           FilterContext filterContext, List<ZipEntry> translatableEntries,
                                           Comparator<ZipEntry> entryComparator, ZipEntry zipEntry) {
-        if (entryComparator == null || zipOutputStream != null) {
+        if (zipOutputStream != null && entryComparator == null) {
+            // No need to reorder entries; translate immediately while writing output
             translateEntry(zipFile, zipOutputStream, writer, filterContext, zipEntry);
         } else {
+            // Either we are only parsing the archive (zipOutputStream is null)
+            // or we want to sort entries before writing them. Store for later.
             translatableEntries.add(zipEntry);
         }
     }


### PR DESCRIPTION
## Summary
- avoid calling `translateEntry` when reading ZIP archives without an output stream

## Testing
- `./gradlew test` *(fails: Unable to download toolchain, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_684fd4b136d48328855d64e19d3a75e4