### PR TITLE
Fix NPE in SDL project filter

### DIFF
--- a/src/org/omegat/filters4/AbstractZipFilter.java
+++ b/src/org/omegat/filters4/AbstractZipFilter.java
@@ -208,6 +208,9 @@ public abstract class AbstractZipFilter extends AbstractFilter {
     }
 
     private void copyUnchangedEntry(ZipFile zipFile, ZipOutputStream zipOutputStream, ZipEntry zipEntry) throws IOException {
+        if (zipOutputStream == null) {
+            return;
+        }
         ZipEntry outputEntry = new ZipEntry(zipEntry.getName());
         zipOutputStream.putNextEntry(outputEntry);
         org.apache.commons.io.IOUtils.copy(zipFile.getInputStream(zipEntry), zipOutputStream);


### PR DESCRIPTION
## Summary
- safeguard copyUnchangedEntry against null `ZipOutputStream`

## Testing
- `./gradlew assemble` *(fails: Could not download toolchain due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685026b6360883288ba0e84e37596806