### PR TITLE
Fix SdlProject filter null pointer

### DIFF
--- a/src/org/omegat/filters4/xml/xliff/SdlProject.java
+++ b/src/org/omegat/filters4/xml/xliff/SdlProject.java
@@ -26,6 +26,7 @@
 package org.omegat.filters4.xml.xliff;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.zip.ZipEntry;
 
 import org.omegat.core.Core;
@@ -81,5 +82,10 @@ public class SdlProject extends AbstractZipFilter {
         SdlXliff xmlfilter = new SdlXliff();
         xmlfilter.setCallbacks(entryParseCallback, entryTranslateCallback);
         return xmlfilter;
+    }
+
+    @Override
+    protected Comparator<ZipEntry> getEntryComparator() {
+        return Comparator.comparing(ZipEntry::getName);
     }
 }


### PR DESCRIPTION
## Summary
- avoid NPE by defining entry comparator in `SdlProject`

## Testing
- `./gradlew testClasses` *(fails: Could not resolve docbook-xml due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68511142606c8328ae750481a5e75ab9