### PR TITLE
Enable parallel TM match search

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1818,6 +1818,7 @@ EXT_TMX_SORT_KEY_ADJUSTED_SCORE=Full text, including tags and numbers
 EXT_TMX_FUZZY_THRESHOLD_KEY=Minimal threshold to show a fuzzy match:
 EXT_SEGMENTED_DESCRIPTION=When using paragraph segmentation:
 PARAGRAPH_MATCH_FROM_SEGMENT_TMX= Show matches assembled from multiple segments
+TM_SEARCH_PARALLEL=Use multiple threads for TM search
 PREFS_TITLE_TM_MATCHES=TM Matches
 
 # ViewOptions

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -37,6 +37,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -99,7 +102,8 @@ public class FindMatches {
 
     private static final String ORPHANED_FILE_NAME = OStrings.getString("CT_ORPHAN_STRINGS");
 
-    private final ISimilarityCalculator distance = new LevenshteinDistance();
+    private final ThreadLocal<ISimilarityCalculator> distance =
+            ThreadLocal.withInitial(LevenshteinDistance::new);
 
     /**
      * the removePattern that was configured by the user.
@@ -132,6 +136,35 @@ public class FindMatches {
     private final int fuzzyMatchThreshold;
 
     private final Segmenter segmenter;
+
+    private static class Candidate {
+        final EntryKey key;
+        final ITMXEntry entry;
+        final String tmx;
+        final NearString.MATCH_SOURCE source;
+        final boolean fuzzy;
+        final int penalty;
+
+        Candidate(EntryKey key, ITMXEntry entry, String tmx, NearString.MATCH_SOURCE source,
+                boolean fuzzy, int penalty) {
+            this.key = key;
+            this.entry = entry;
+            this.tmx = tmx;
+            this.source = source;
+            this.fuzzy = fuzzy;
+            this.penalty = penalty;
+        }
+    }
+
+    private static class ProcessedCandidate {
+        final Candidate cand;
+        final NearString near;
+
+        ProcessedCandidate(Candidate cand, NearString near) {
+            this.cand = cand;
+            this.near = near;
+        }
+    }
 
     /**
      * Constructs a FindMatches instance for finding fuzzy matched translation memories.
@@ -273,12 +306,12 @@ public class FindMatches {
         strTokensNoStem = tokenizeNoStem(srcText);
         strTokensAll = tokenizeAll(srcText);
 
-        // travel by project entries, including orphaned
+        List<Candidate> candidates = new ArrayList<>();
+
         if (project.getProjectProperties().isSupportDefaultTranslations()) {
             project.iterateByDefaultTranslations((source, trans) -> {
                 checkStopped(stop);
                 if (!searchExactlyTheSame && source.equals(searchText)) {
-                    // skip original==original entry comparison
                     return;
                 }
                 if (trans.translation == null) {
@@ -287,13 +320,13 @@ public class FindMatches {
                 String fileName = project.isOrphaned(source) ? ORPHANED_FILE_NAME : null;
                 PrepareTMXEntry entry = new PrepareTMXEntry(trans);
                 entry.source = source;
-                processEntry(null, entry, fileName, NearString.MATCH_SOURCE.MEMORY, false, 0);
+                candidates.add(new Candidate(null, entry, fileName, NearString.MATCH_SOURCE.MEMORY, false, 0));
             });
         }
+
         project.iterateByMultipleTranslations((source, trans) -> {
             checkStopped(stop);
             if (!searchExactlyTheSame && source.sourceText.equals(searchText)) {
-                // skip original==original entry comparison
                 return;
             }
             if (trans.translation == null) {
@@ -302,12 +335,9 @@ public class FindMatches {
             String fileName = project.isOrphaned(source) ? ORPHANED_FILE_NAME : null;
             PrepareTMXEntry entry = new PrepareTMXEntry(trans);
             entry.source = source.sourceText;
-            processEntry(source, entry, fileName, NearString.MATCH_SOURCE.MEMORY, false, 0);
+            candidates.add(new Candidate(source, entry, fileName, NearString.MATCH_SOURCE.MEMORY, false, 0));
         });
-        /*
-         * Penalty applied for fuzzy matches in another language (if no match in
-         * the target language was found).
-         */
+
         int foreignPenalty = Preferences.getPreferenceDefault(Preferences.PENALTY_FOR_FOREIGN_MATCHES,
                 Preferences.PENALTY_FOR_FOREIGN_MATCHES_DEFAULT);
         for (Map.Entry<String, ExternalTMX> en : project.getTransMemories().entrySet()) {
@@ -318,32 +348,41 @@ public class FindMatches {
             }
             for (ITMXEntry tmen : en.getValue().getEntries()) {
                 checkStopped(stop);
-                if (tmen.getSourceText() == null) {
-                    // Not all TMX entries have a source; skip it in
-                    // the case, because of no meaningful.
-                    continue;
-                }
-                if (tmen.getTranslationText() == null) {
+                if (tmen.getSourceText() == null || tmen.getTranslationText() == null) {
                     continue;
                 }
                 int tmenPenalty = penalty;
                 if (tmen.hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true")) {
                     tmenPenalty += foreignPenalty;
                 }
-                processEntry(null, tmen, en.getKey(), NearString.MATCH_SOURCE.TM, false, tmenPenalty);
+                candidates.add(new Candidate(null, tmen, en.getKey(), NearString.MATCH_SOURCE.TM, false, tmenPenalty));
             }
         }
 
-        // travel by all entries for check source file translations
         for (SourceTextEntry ste : project.getAllEntries()) {
             checkStopped(stop);
             if (ste.getSourceTranslation() != null) {
                 PrepareTMXEntry entry = new PrepareTMXEntry();
                 entry.source = ste.getSrcText();
                 entry.translation = ste.getSourceTranslation();
-                processEntry(ste.getKey(), entry, ste.getKey().file, NearString.MATCH_SOURCE.FILES,
-                        ste.isSourceTranslationFuzzy(), 0);
+                candidates.add(new Candidate(ste.getKey(), entry, ste.getKey().file, NearString.MATCH_SOURCE.FILES,
+                        ste.isSourceTranslationFuzzy(), 0));
             }
+        }
+
+        boolean parallel = Preferences.isPreferenceDefault(Preferences.TM_SEARCH_PARALLEL, false)
+                && Runtime.getRuntime().availableProcessors() > 1;
+        Stream<Candidate> stream = parallel ? candidates.parallelStream() : candidates.stream();
+
+        List<ProcessedCandidate> processed = stream.map(c -> buildCandidate(c, stop))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        processed.sort(Comparator.comparing((ProcessedCandidate pc) -> pc.near.scores[0],
+                new NearString.ScoresComparator(NearString.SORT_KEY.SCORE)).reversed());
+
+        for (ProcessedCandidate pc : processed) {
+            addNearString(result, pc.cand.key, pc.cand.entry, pc.near);
         }
         if (runSeparateSegmentMatch) {
             FindMatches separateSegmentMatcher = new FindMatches(project, segmenter, 1, true,
@@ -438,7 +477,7 @@ public class FindMatches {
         Token[] candTokens = tokenizeStem(realSource);
 
         // First percent value - with stemming if possible
-        int similarityStem = FuzzyMatcher.calcSimilarity(distance, strTokensStem, candTokens);
+        int similarityStem = FuzzyMatcher.calcSimilarity(distance.get(), strTokensStem, candTokens);
 
         similarityStem -= penalty;
         if (fuzzy) {
@@ -454,7 +493,7 @@ public class FindMatches {
 
         Token[] candTokensNoStem = tokenizeNoStem(realSource);
         // Second percent value - without stemming
-        int similarityNoStem = FuzzyMatcher.calcSimilarity(distance, strTokensNoStem, candTokensNoStem);
+        int similarityNoStem = FuzzyMatcher.calcSimilarity(distance.get(), strTokensNoStem, candTokensNoStem);
         similarityNoStem -= penalty;
         if (fuzzy) {
             // penalty for fuzzy
@@ -469,7 +508,7 @@ public class FindMatches {
 
         Token[] candTokensAll = tokenizeAll(realSource);
         // Third percent value - with numbers, tags, etc.
-        int simAdjusted = FuzzyMatcher.calcSimilarity(distance, strTokensAll, candTokensAll);
+        int simAdjusted = FuzzyMatcher.calcSimilarity(distance.get(), strTokensAll, candTokensAll);
         simAdjusted -= penalty;
         if (fuzzy) {
             // penalty for fuzzy
@@ -563,18 +602,105 @@ public class FindMatches {
         }
     }
 
+    private void addNearString(List<NearString> list, EntryKey key, ITMXEntry entry, NearString near) {
+        final String source = near.source;
+        final String translation = near.translation;
+        NearString.Scores scores = near.scores[0];
+        int pos = 0;
+        for (int i = 0; i < list.size(); i++) {
+            NearString st = list.get(i);
+            if (source.equals(st.source) && Objects.equals(translation, st.translation)) {
+                list.set(i, NearString.merge(st, key, entry, near.comesFrom, near.fuzzyMark, scores, null,
+                        near.projs[0]));
+                return;
+            }
+            if (st.scores[0].score < scores.score) {
+                break;
+            }
+            if (st.scores[0].score == scores.score) {
+                if (st.scores[0].scoreNoStem < scores.scoreNoStem) {
+                    break;
+                }
+                if (st.scores[0].scoreNoStem == scores.scoreNoStem) {
+                    if (st.scores[0].adjustedScore < scores.adjustedScore) {
+                        break;
+                    }
+                    if (scores.score == 100 && !st.source.equals(srcText) && source.equals(srcText)) {
+                        break;
+                    }
+                }
+            }
+            pos = i + 1;
+        }
+        list.add(pos, near);
+        if (list.size() > maxCount) {
+            list.remove(list.size() - 1);
+        }
+    }
+
+    private ProcessedCandidate buildCandidate(Candidate cand, IStopped stop) {
+        checkStopped(stop);
+        String realSource = cand.entry.getSourceText();
+        int realPenaltyForRemoved = 0;
+        if (removePattern != null) {
+            StringBuilder entryRemovedText = new StringBuilder();
+            Matcher removeMatcher = removePattern.matcher(realSource);
+            while (removeMatcher.find()) {
+                entryRemovedText.append(removeMatcher.group());
+            }
+            realSource = removeMatcher.replaceAll("");
+            if (!entryRemovedText.toString().equals(removedText)) {
+                realPenaltyForRemoved = PENALTY_FOR_REMOVED;
+            }
+        }
+
+        Token[] candTokens = tokenizeStem(realSource);
+        int similarityStem = FuzzyMatcher.calcSimilarity(distance.get(), strTokensStem, candTokens);
+        similarityStem -= cand.penalty;
+        if (cand.fuzzy) {
+            similarityStem -= PENALTY_FOR_FUZZY;
+        }
+        similarityStem -= realPenaltyForRemoved;
+
+        Token[] candTokensNoStem = tokenizeNoStem(realSource);
+        int similarityNoStem = FuzzyMatcher.calcSimilarity(distance.get(), strTokensNoStem, candTokensNoStem);
+        similarityNoStem -= cand.penalty;
+        if (cand.fuzzy) {
+            similarityNoStem -= PENALTY_FOR_FUZZY;
+        }
+        similarityNoStem -= realPenaltyForRemoved;
+
+        Token[] candTokensAll = tokenizeAll(realSource);
+        int simAdjusted = FuzzyMatcher.calcSimilarity(distance.get(), strTokensAll, candTokensAll);
+        simAdjusted -= cand.penalty;
+        if (cand.fuzzy) {
+            simAdjusted -= PENALTY_FOR_FUZZY;
+        }
+        simAdjusted -= realPenaltyForRemoved;
+
+        if (fuzzyMatchThreshold > 0 && similarityStem < fuzzyMatchThreshold
+                && similarityNoStem < fuzzyMatchThreshold && simAdjusted < fuzzyMatchThreshold) {
+            return null;
+        }
+
+        NearString near = new NearString(cand.key, cand.entry, cand.source, cand.fuzzy,
+                new NearString.Scores(similarityStem, similarityNoStem, simAdjusted, cand.penalty), null, cand.tmx);
+        return new ProcessedCandidate(cand, near);
+    }
+
     /*
      * Methods for tokenize strings with caching.
      */
-    Map<String, Token[]> tokenizeStemCache = new HashMap<>();
-    Map<String, Token[]> tokenizeNoStemCache = new HashMap<>();
-    Map<String, Token[]> tokenizeAllCache = new HashMap<>();
+    ThreadLocal<Map<String, Token[]>> tokenizeStemCache = ThreadLocal.withInitial(HashMap::new);
+    ThreadLocal<Map<String, Token[]>> tokenizeNoStemCache = ThreadLocal.withInitial(HashMap::new);
+    ThreadLocal<Map<String, Token[]>> tokenizeAllCache = ThreadLocal.withInitial(HashMap::new);
 
     Token[] tokenizeStem(String str) {
-        Token[] tokens = tokenizeStemCache.get(str);
+        Map<String, Token[]> cache = tokenizeStemCache.get();
+        Token[] tokens = cache.get(str);
         if (tokens == null) {
             tokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.MATCHING);
-            tokenizeStemCache.put(str, tokens);
+            cache.put(str, tokens);
         }
         return tokens;
     }
@@ -583,10 +709,11 @@ public class FindMatches {
         // No-stemming token comparisons are intentionally case-insensitive
         // for matching purposes.
         str = str.toLowerCase(srcLocale);
-        Token[] tokens = tokenizeNoStemCache.get(str);
+        Map<String, Token[]> cache = tokenizeNoStemCache.get();
+        Token[] tokens = cache.get(str);
         if (tokens == null) {
             tokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.NONE);
-            tokenizeNoStemCache.put(str, tokens);
+            cache.put(str, tokens);
         }
         return tokens;
     }
@@ -595,10 +722,11 @@ public class FindMatches {
         // Verbatim token comparisons are intentionally case-insensitive.
         // for matching purposes.
         str = str.toLowerCase(srcLocale);
-        Token[] tokens = tokenizeAllCache.get(str);
+        Map<String, Token[]> cache = tokenizeAllCache.get();
+        Token[] tokens = cache.get(str);
         if (tokens == null) {
             tokens = tok.tokenizeVerbatim(str);
-            tokenizeAllCache.put(str, tokens);
+            cache.put(str, tokens);
         }
         return tokens;
     }

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -37,8 +37,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.Comparator;
-import java.util.stream.Collectors;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Stream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -156,15 +156,6 @@ public class FindMatches {
         }
     }
 
-    private static class ProcessedCandidate {
-        final Candidate cand;
-        final NearString near;
-
-        ProcessedCandidate(Candidate cand, NearString near) {
-            this.cand = cand;
-            this.near = near;
-        }
-    }
 
     /**
      * Constructs a FindMatches instance for finding fuzzy matched translation memories.
@@ -306,6 +297,16 @@ public class FindMatches {
         strTokensNoStem = tokenizeNoStem(srcText);
         strTokensAll = tokenizeAll(srcText);
 
+        boolean parallel = Preferences.isPreferenceDefault(Preferences.TM_SEARCH_PARALLEL, false)
+                && Runtime.getRuntime().availableProcessors() > 1;
+
+        Queue<List<NearString>> partialResults = new ConcurrentLinkedQueue<>();
+        ThreadLocal<List<NearString>> localResults = ThreadLocal.withInitial(() -> {
+            List<NearString> list = new ArrayList<>(maxCount + 1);
+            partialResults.add(list);
+            return list;
+        });
+
         List<Candidate> candidates = new ArrayList<>();
 
         if (project.getProjectProperties().isSupportDefaultTranslations()) {
@@ -322,6 +323,8 @@ public class FindMatches {
                 entry.source = source;
                 candidates.add(new Candidate(null, entry, fileName, NearString.MATCH_SOURCE.MEMORY, false, 0));
             });
+            processCandidates(candidates, parallel, stop, localResults);
+            candidates.clear();
         }
 
         project.iterateByMultipleTranslations((source, trans) -> {
@@ -337,6 +340,8 @@ public class FindMatches {
             entry.source = source.sourceText;
             candidates.add(new Candidate(source, entry, fileName, NearString.MATCH_SOURCE.MEMORY, false, 0));
         });
+        processCandidates(candidates, parallel, stop, localResults);
+        candidates.clear();
 
         int foreignPenalty = Preferences.getPreferenceDefault(Preferences.PENALTY_FOR_FOREIGN_MATCHES,
                 Preferences.PENALTY_FOR_FOREIGN_MATCHES_DEFAULT);
@@ -357,6 +362,8 @@ public class FindMatches {
                 }
                 candidates.add(new Candidate(null, tmen, en.getKey(), NearString.MATCH_SOURCE.TM, false, tmenPenalty));
             }
+            processCandidates(candidates, parallel, stop, localResults);
+            candidates.clear();
         }
 
         for (SourceTextEntry ste : project.getAllEntries()) {
@@ -369,21 +376,16 @@ public class FindMatches {
                         ste.isSourceTranslationFuzzy(), 0));
             }
         }
+        processCandidates(candidates, parallel, stop, localResults);
+        candidates.clear();
 
-        boolean parallel = Preferences.isPreferenceDefault(Preferences.TM_SEARCH_PARALLEL, false)
-                && Runtime.getRuntime().availableProcessors() > 1;
-        Stream<Candidate> stream = parallel ? candidates.parallelStream() : candidates.stream();
-
-        List<ProcessedCandidate> processed = stream.map(c -> buildCandidate(c, stop))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-
-        processed.sort(Comparator.comparing((ProcessedCandidate pc) -> pc.near.scores[0],
-                new NearString.ScoresComparator(NearString.SORT_KEY.SCORE)).reversed());
-
-        for (ProcessedCandidate pc : processed) {
-            addNearString(result, pc.cand.key, pc.cand.entry, pc.near);
+        List<NearString> merged = new ArrayList<>(maxCount + 1);
+        for (List<NearString> list : partialResults) {
+            for (NearString ns : list) {
+                addNearString(merged, ns);
+            }
         }
+        result.addAll(merged);
         if (runSeparateSegmentMatch) {
             FindMatches separateSegmentMatcher = new FindMatches(project, segmenter, 1, true,
                     fuzzyMatchThreshold);
@@ -602,7 +604,7 @@ public class FindMatches {
         }
     }
 
-    private void addNearString(List<NearString> list, EntryKey key, ITMXEntry entry, NearString near) {
+    private void addNearString(List<NearString> list, NearString near) {
         final String source = near.source;
         final String translation = near.translation;
         NearString.Scores scores = near.scores[0];
@@ -610,8 +612,10 @@ public class FindMatches {
         for (int i = 0; i < list.size(); i++) {
             NearString st = list.get(i);
             if (source.equals(st.source) && Objects.equals(translation, st.translation)) {
-                list.set(i, NearString.merge(st, key, entry, near.comesFrom, near.fuzzyMark, scores, null,
-                        near.projs[0]));
+                list.set(i, NearString.merge(st, near.key, near.source, near.translation, near.comesFrom,
+                        near.fuzzyMark, scores.score, scores.scoreNoStem, scores.adjustedScore, near.attr,
+                        near.projs[0], near.creator, near.creationDate, near.changer, near.changedDate,
+                        near.props));
                 return;
             }
             if (st.scores[0].score < scores.score) {
@@ -638,7 +642,18 @@ public class FindMatches {
         }
     }
 
-    private ProcessedCandidate buildCandidate(Candidate cand, IStopped stop) {
+    private void processCandidates(List<Candidate> candidates, boolean parallel, IStopped stop,
+            ThreadLocal<List<NearString>> localResults) {
+        Stream<Candidate> stream = parallel ? candidates.parallelStream() : candidates.stream();
+        stream.forEach(c -> {
+            NearString near = buildCandidate(c, stop);
+            if (near != null) {
+                addNearString(localResults.get(), near);
+            }
+        });
+    }
+
+    private NearString buildCandidate(Candidate cand, IStopped stop) {
         checkStopped(stop);
         String realSource = cand.entry.getSourceText();
         int realPenaltyForRemoved = 0;
@@ -685,7 +700,7 @@ public class FindMatches {
 
         NearString near = new NearString(cand.key, cand.entry, cand.source, cand.fuzzy,
                 new NearString.Scores(similarityStem, similarityNoStem, simAdjusted, cand.penalty), null, cand.tmx);
-        return new ProcessedCandidate(cand, near);
+        return near;
     }
 
     /*

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -362,6 +362,9 @@ public final class Preferences {
     public static final String EXT_TMX_FUZZY_MATCH_THRESHOLD = "ext_tmx_fuzzy_match_threshold";
     /** paragraph match from segment TMX */
     public static final String PARAGRAPH_MATCH_FROM_SEGMENT_TMX = "paragraph_match_from_segment_tmx";
+    /** Use parallel TM search */
+    public static final String TM_SEARCH_PARALLEL = "tm_search_parallel";
+    public static final boolean TM_SEARCH_PARALLEL_DEFAULT = false;
 
     /** View options: Show all sources in bold */
     public static final String VIEW_OPTION_SOURCE_ALL_BOLD = "view_option_source_all_bold";

--- a/test/src/org/omegat/core/statistics/FindMatchesLargeTMXTest.java
+++ b/test/src/org/omegat/core/statistics/FindMatchesLargeTMXTest.java
@@ -1,0 +1,68 @@
+package org.omegat.core.statistics;
+
+import static org.junit.Assert.assertFalse;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.core.data.IProject;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.statistics.FindMatches;
+import org.omegat.core.statistics.FindMatchesTest.TestProject;
+import org.omegat.core.matching.NearString;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.tokenizer.DefaultTokenizer;
+import org.omegat.tokenizer.LuceneEnglishTokenizer;
+import org.omegat.util.Preferences;
+import org.omegat.util.TestPreferencesInitializer;
+
+public class FindMatchesLargeTMXTest {
+    private Path tempDir;
+    private Path tmx;
+
+    @Before
+    public void setup() throws Exception {
+        tempDir = Files.createTempDirectory("largeTM");
+        tmx = Files.createTempFile("large", ".tmx");
+        try (PrintWriter pw = new PrintWriter(Files.newBufferedWriter(tmx, StandardCharsets.UTF_8))) {
+            pw.println("<?xml version='1.0' encoding='UTF-8'?>");
+            pw.println("<!DOCTYPE tmx SYSTEM 'tmx14.dtd'>");
+            pw.println("<tmx version='1.4'>");
+            pw.println("<header creationtool='OmegaT' creationtoolversion='test' segtype='sentence' adminlang='en' srclang='en' datatype='PlainText'/>");
+            pw.println("<body>");
+            for (int i = 0; i < 10000; i++) {
+                pw.println("<tu><tuv xml:lang='en'><seg>src" + i + "</seg></tuv><tuv xml:lang='en'><seg>trg" + i + "</seg></tuv></tu>");
+            }
+            pw.println("</body></tmx>");
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Files.deleteIfExists(tmx);
+        Files.deleteIfExists(tempDir);
+    }
+
+    @Test
+    public void testLargeTmxSearch() throws Exception {
+        TestPreferencesInitializer.init();
+        Preferences.setPreference(Preferences.TM_SEARCH_PARALLEL, true);
+        Segmenter seg = new Segmenter(Preferences.getSRX());
+        ProjectProperties prop = new ProjectProperties(tempDir.toFile());
+        prop.setSourceLanguage("en");
+        prop.setTargetLanguage("en");
+        prop.setSupportDefaultTranslations(false);
+        IProject project = new FindMatchesTest.TestProject(prop, null, tmx.toFile(), new LuceneEnglishTokenizer(), new DefaultTokenizer(), seg);
+        FindMatches finder = new FindMatches(project, seg, 5, false, 50);
+        List<NearString> res = finder.search("src1", false, () -> false);
+        assertFalse(res.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add `TM_SEARCH_PARALLEL` preference flag
- parallelize translation memory search using new Candidate list
- maintain thread-local caches and distance calculators

## Testing
- `./gradlew test` *(fails: Could not download JDK)*
- `./gradlew -x test classes` *(fails: Could not download JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68567df5f0c88328a3edce9326958824