### PR TITLE
Enhance MT and fuzzy autocompletion

### DIFF
--- a/src/org/omegat/gui/exttrans/MachineTranslationAutoCompleterView.java
+++ b/src/org/omegat/gui/exttrans/MachineTranslationAutoCompleterView.java
@@ -7,10 +7,12 @@ import java.util.Set;
 import java.util.HashSet;
 
 import org.omegat.core.Core;
+import org.omegat.gui.editor.autocompleter.AutoCompleter;
 import org.omegat.gui.editor.autocompleter.AutoCompleterItem;
 import org.omegat.gui.editor.autocompleter.AutoCompleterListView;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
+import org.omegat.util.StringUtil;
 import org.omegat.tokenizer.ITokenizer;
 
 /**
@@ -41,8 +43,9 @@ public class MachineTranslationAutoCompleterView extends AutoCompleterListView {
                     all.add(new AutoCompleterItem(word, new String[] { info.translatorName }, 0));
                 }
                 if (!token.isEmpty() && word.startsWith(token) && !word.equals(token)) {
-                    if (seenContext.add(word)) {
-                        contextual.add(new AutoCompleterItem(word, new String[] { info.translatorName }, token.length()));
+                    String payload = StringUtil.matchCapitalization(word, token, getTargetLocale());
+                    if (seenContext.add(payload)) {
+                        contextual.add(new AutoCompleterItem(payload, new String[] { info.translatorName }, token.length()));
                     }
                 }
             }
@@ -52,6 +55,19 @@ public class MachineTranslationAutoCompleterView extends AutoCompleterListView {
             return contextual;
         }
         return all;
+    }
+
+    @Override
+    public boolean shouldPopUp() {
+        String leadingText = getLeadingText();
+        List<AutoCompleterItem> entries = computeListData(leadingText, true);
+        return !entries.isEmpty()
+                && (leadingText.codePointCount(0, leadingText.length()) > 1
+                        || entries.size() <= AutoCompleter.PAGE_ROW_COUNT);
+    }
+
+    private java.util.Locale getTargetLocale() {
+        return getTargetLanguage().getLocale();
     }
 
     @Override

--- a/src/org/omegat/gui/matches/FuzzyMatchesAutoCompleterView.java
+++ b/src/org/omegat/gui/matches/FuzzyMatchesAutoCompleterView.java
@@ -10,8 +10,10 @@ import org.omegat.core.Core;
 import org.omegat.core.matching.NearString;
 import org.omegat.gui.editor.autocompleter.AutoCompleterItem;
 import org.omegat.gui.editor.autocompleter.AutoCompleterListView;
+import org.omegat.gui.editor.autocompleter.AutoCompleter;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
+import org.omegat.util.StringUtil;
 import org.omegat.tokenizer.ITokenizer;
 
 /**
@@ -43,8 +45,9 @@ public class FuzzyMatchesAutoCompleterView extends AutoCompleterListView {
                     all.add(new AutoCompleterItem(word, null, 0));
                 }
                 if (!token.isEmpty() && word.startsWith(token) && !word.equals(token)) {
-                    if (seenContext.add(word)) {
-                        contextual.add(new AutoCompleterItem(word, null, token.length()));
+                    String payload = org.omegat.util.StringUtil.matchCapitalization(word, token, getTargetLocale());
+                    if (seenContext.add(payload)) {
+                        contextual.add(new AutoCompleterItem(payload, null, token.length()));
                     }
                 }
             }
@@ -54,6 +57,19 @@ public class FuzzyMatchesAutoCompleterView extends AutoCompleterListView {
             return contextual;
         }
         return all;
+    }
+
+    private java.util.Locale getTargetLocale() {
+        return getTargetLanguage().getLocale();
+    }
+
+    @Override
+    public boolean shouldPopUp() {
+        String leadingText = getLeadingText();
+        List<AutoCompleterItem> entries = computeListData(leadingText, true);
+        return !entries.isEmpty()
+                && (leadingText.codePointCount(0, leadingText.length()) > 1
+                        || entries.size() <= AutoCompleter.PAGE_ROW_COUNT);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- show fuzzy and MT suggestions with matched capitalization
- gate fuzzy and MT popups on context length

## Testing
- `./gradlew -Dorg.gradle.java.installations.auto-download=false test` *(fails: Could not download required JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68567e7bc01083289db8955595241f7f