### PR TITLE
Add capitalization & popup rules to MT/Fuzzy autocomplete

### DIFF
--- a/src/org/omegat/gui/exttrans/MachineTranslationAutoCompleterView.java
+++ b/src/org/omegat/gui/exttrans/MachineTranslationAutoCompleterView.java
@@ -5,12 +5,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.Locale;
 
 import org.omegat.core.Core;
 import org.omegat.gui.editor.autocompleter.AutoCompleterItem;
 import org.omegat.gui.editor.autocompleter.AutoCompleterListView;
+import org.omegat.gui.editor.autocompleter.AutoCompleter;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
+import org.omegat.util.StringUtil;
 import org.omegat.tokenizer.ITokenizer;
 
 /**
@@ -28,7 +31,9 @@ public class MachineTranslationAutoCompleterView extends AutoCompleterListView {
         if (infos == null || infos.isEmpty()) {
             return Collections.emptyList();
         }
+        Locale locale = getTargetLanguage().getLocale();
         String token = getLastToken(prevText);
+        String tokenLower = token.toLowerCase(locale);
         List<AutoCompleterItem> contextual = new ArrayList<>();
         List<AutoCompleterItem> all = new ArrayList<>();
         Set<String> seenContext = new HashSet<>();
@@ -37,12 +42,14 @@ public class MachineTranslationAutoCompleterView extends AutoCompleterListView {
             String tr = info.result;
             String[] words = getTokenizer().tokenizeWordsToStrings(tr, ITokenizer.StemmingMode.NONE);
             for (String word : words) {
-                if (seenAll.add(word)) {
+                String lower = word.toLowerCase(locale);
+                if (seenAll.add(lower)) {
                     all.add(new AutoCompleterItem(word, new String[] { info.translatorName }, 0));
                 }
-                if (!token.isEmpty() && word.startsWith(token) && !word.equals(token)) {
-                    if (seenContext.add(word)) {
-                        contextual.add(new AutoCompleterItem(word, new String[] { info.translatorName }, token.length()));
+                if (!token.isEmpty() && lower.startsWith(tokenLower) && !lower.equals(tokenLower)) {
+                    if (seenContext.add(lower)) {
+                        String payload = StringUtil.matchCapitalization(word, token, locale);
+                        contextual.add(new AutoCompleterItem(payload, new String[] { info.translatorName }, token.length()));
                     }
                 }
             }
@@ -52,6 +59,15 @@ public class MachineTranslationAutoCompleterView extends AutoCompleterListView {
             return contextual;
         }
         return all;
+    }
+
+    @Override
+    public boolean shouldPopUp() {
+        String leadingText = getLeadingText();
+        List<AutoCompleterItem> entries = computeListData(leadingText, true);
+        return !entries.isEmpty()
+                && (leadingText.codePointCount(0, leadingText.length()) > 1
+                        || entries.size() <= AutoCompleter.PAGE_ROW_COUNT);
     }
 
     @Override

--- a/src/org/omegat/gui/matches/FuzzyMatchesAutoCompleterView.java
+++ b/src/org/omegat/gui/matches/FuzzyMatchesAutoCompleterView.java
@@ -5,13 +5,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.Locale;
 
 import org.omegat.core.Core;
 import org.omegat.core.matching.NearString;
 import org.omegat.gui.editor.autocompleter.AutoCompleterItem;
 import org.omegat.gui.editor.autocompleter.AutoCompleterListView;
+import org.omegat.gui.editor.autocompleter.AutoCompleter;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
+import org.omegat.util.StringUtil;
 import org.omegat.tokenizer.ITokenizer;
 
 /**
@@ -30,7 +33,9 @@ public class FuzzyMatchesAutoCompleterView extends AutoCompleterListView {
         if (matches.isEmpty()) {
             return Collections.emptyList();
         }
+        Locale locale = getTargetLanguage().getLocale();
         String token = getLastToken(prevText);
+        String tokenLower = token.toLowerCase(locale);
         List<AutoCompleterItem> contextual = new ArrayList<>();
         List<AutoCompleterItem> all = new ArrayList<>();
         Set<String> seenContext = new HashSet<>();
@@ -39,12 +44,14 @@ public class FuzzyMatchesAutoCompleterView extends AutoCompleterListView {
             String trans = ns.translation;
             String[] words = getTokenizer().tokenizeWordsToStrings(trans, ITokenizer.StemmingMode.NONE);
             for (String word : words) {
-                if (seenAll.add(word)) {
+                String lower = word.toLowerCase(locale);
+                if (seenAll.add(lower)) {
                     all.add(new AutoCompleterItem(word, null, 0));
                 }
-                if (!token.isEmpty() && word.startsWith(token) && !word.equals(token)) {
-                    if (seenContext.add(word)) {
-                        contextual.add(new AutoCompleterItem(word, null, token.length()));
+                if (!token.isEmpty() && lower.startsWith(tokenLower) && !lower.equals(tokenLower)) {
+                    if (seenContext.add(lower)) {
+                        String payload = StringUtil.matchCapitalization(word, token, locale);
+                        contextual.add(new AutoCompleterItem(payload, null, token.length()));
                     }
                 }
             }
@@ -54,6 +61,15 @@ public class FuzzyMatchesAutoCompleterView extends AutoCompleterListView {
             return contextual;
         }
         return all;
+    }
+
+    @Override
+    public boolean shouldPopUp() {
+        String leadingText = getLeadingText();
+        List<AutoCompleterItem> entries = computeListData(leadingText, true);
+        return !entries.isEmpty()
+                && (leadingText.codePointCount(0, leadingText.length()) > 1
+                        || entries.size() <= AutoCompleter.PAGE_ROW_COUNT);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add locale-aware capitalization matching for fuzzy match autocomplete
- add locale-aware capitalization matching for machine translation autocomplete
- control popup display like the glossary view

## Testing
- `./gradlew test --no-daemon` *(fails: Could not download JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68567e7bc01083289db8955595241f7f