### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -612,10 +612,16 @@ public class FindMatches {
         for (int i = 0; i < list.size(); i++) {
             NearString st = list.get(i);
             if (source.equals(st.source) && Objects.equals(translation, st.translation)) {
-                list.set(i, NearString.merge(st, near.key, near.source, near.translation, near.comesFrom,
-                        near.fuzzyMark, scores.score, scores.scoreNoStem, scores.adjustedScore, near.attr,
-                        near.projs[0], near.creator, near.creationDate, near.changer, near.changedDate,
-                        near.props));
+                PrepareTMXEntry entry = new PrepareTMXEntry();
+                entry.source = near.source;
+                entry.translation = near.translation;
+                entry.creator = near.creator;
+                entry.creationDate = near.creationDate;
+                entry.changer = near.changer;
+                entry.changeDate = near.changedDate;
+                entry.otherProperties = near.props;
+                list.set(i, NearString.merge(st, near.key, entry, near.comesFrom, near.fuzzyMark, scores,
+                        near.attr, near.projs[0]));
                 return;
             }
             if (st.scores[0].score < scores.score) {


### PR DESCRIPTION
## Summary
- avoid deprecated `NearString.merge` overload

## Testing
- `./gradlew test` *(fails: Plugin `org.gradle.toolchains.foojay-resolver-convention` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858066b27f883288c916b04410c26b5