### PR TITLE
Add tag-stripped duplicate target QA check

### DIFF
--- a/scripts/check_rules.groovy
+++ b/scripts/check_rules.groovy
@@ -108,6 +108,8 @@ checkSpellErr = false
 nameSpellErr = res.getString("nameSpellErr")
 checkSameTargetDiffSource = true
 nameSameTargetDiffSource = res.getString("nameSameTargetDiffSource")
+checkSameTargetDiffSourceNoTags = true
+nameSameTargetDiffSourceNoTags = res.getString("nameSameTargetDiffSourceNoTags")
 
 
 /*
@@ -193,6 +195,7 @@ if (!prop) {
 def QAcheck() {
     rules = ruleset.clone()
     def tgtIndex = [:].withDefault { [] }
+    def tgtIndexNoTags = [:].withDefault { [] }
 // Prefs
     maxCharLengthAbove=240
     minCharLengthAbove=40
@@ -287,6 +290,9 @@ def QAcheck() {
             }
             if (target != QA_empty) {
                 tgtIndex[target] << [seg: ste.entryNum(), source: source, target: target]
+                def cleanSrc = source.replaceAll(/<\/?[a-z]+[0-9]* ?\/?>/, '')
+                def cleanTgt = target.replaceAll(/<\/?[a-z]+[0-9]* ?\/?>/, '')
+                tgtIndexNoTags[cleanTgt] << [seg: ste.entryNum(), source: source, sourceClean: cleanSrc, target: target]
             }
 
             rules.each { k, v ->
@@ -306,6 +312,18 @@ def QAcheck() {
                 list.each { occ ->
                     console.println(occ.seg + "\t" + nameSameTargetDiffSource + "\t[" + occ.target + "]")
                     model.data.add([ seg: occ.seg, rule: nameSameTargetDiffSource, source: occ.source, target: occ.target ])
+                    segment_count++
+                }
+            }
+        }
+    }
+    if (checkSameTargetDiffSourceNoTags) {
+        tgtIndexNoTags.each { key, list ->
+            def srcs = list.collect { it.sourceClean }.toSet()
+            if (srcs.size() > 1) {
+                list.each { occ ->
+                    console.println(occ.seg + "\t" + nameSameTargetDiffSourceNoTags + "\t[" + occ.target + "]")
+                    model.data.add([ seg: occ.seg, rule: nameSameTargetDiffSourceNoTags, source: occ.source, target: occ.target ])
                     segment_count++
                 }
             }
@@ -396,6 +414,12 @@ def interfejs(locationxy = new Point(0, 0), width = 900, height = 550, scrollpos
                     checkSameTargetDiffSource = !checkSameTargetDiffSource;
                 },
                 constraints:gbc(gridx:0, gridy:3, weightx: 0.5, fill:GridBagConstraints.HORIZONTAL, insets:[0,5,0,0]))
+            checkBox(text:res.getString("checkSameTargetDiffSourceNoTags"),
+                selected: checkSameTargetDiffSourceNoTags,
+                actionPerformed: {
+                    checkSameTargetDiffSourceNoTags = !checkSameTargetDiffSourceNoTags;
+                },
+                constraints:gbc(gridx:0, gridy:4, weightx: 0.5, fill:GridBagConstraints.HORIZONTAL, insets:[0,5,0,0]))
 
 
             checkBox(text:res.getString("checkLeadSpace"),

--- a/scripts/properties/check_rules.properties
+++ b/scripts/properties/check_rules.properties
@@ -26,6 +26,7 @@ nameTagOrder=Tags - order
 nameNumErr=Inconsistent numbers
 nameSpellErr=Spelling errors(s)
 nameSameTargetDiffSource=Identical target with different source
+nameSameTargetDiffSourceNoTags=Identical target (ignoring tags) with different source
 
 checkWholeProject=Check whole project
 checkLeadSpace=Check for leading whitespace
@@ -45,5 +46,6 @@ checkTagOrder=Check sequence of tags
 checkNumErr=Check for inconsistent numbers
 checkSpellErr=Check for segments with spelling errors
 checkSameTargetDiffSource=Check for identical targets with different sources
+checkSameTargetDiffSourceNoTags=Check for identical targets with different sources ignoring tags
 
 refresh=Refresh


### PR DESCRIPTION
## Summary
- extend `check_rules.groovy` with option to ignore tags when checking identical targets coming from different sources
- expose checkbox for the new rule
- provide English strings for the rule

## Testing
- `./gradlew test` *(fails: Plugin org.gradle.toolchains.foojay-resolver-convention not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f3060a4483289becf097a36deaf9